### PR TITLE
feat: emit Kubernetes events on apply, delete, and reconcile errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -15,15 +15,29 @@ import (
 
 // HandlerContext is passed to sub-reconciler functions. It tracks which
 // resources are read via Fetch so the framework can build a dependency graph.
+// It also provides RecordEvent for emitting custom Kubernetes events on the
+// primary resource being reconciled.
 type HandlerContext struct {
 	ctx        context.Context
 	mgr        *Manager
+	primary    client.Object
 	narrowDeps []depKey
 	broadDeps  []depKeyBroad
 }
 
-func newHandlerContext(ctx context.Context, mgr *Manager) *HandlerContext {
-	return &HandlerContext{ctx: ctx, mgr: mgr}
+func newHandlerContext(ctx context.Context, mgr *Manager, primary client.Object) *HandlerContext {
+	return &HandlerContext{ctx: ctx, mgr: mgr, primary: primary}
+}
+
+// RecordEvent emits a Kubernetes event on the primary resource being reconciled.
+// eventType is "Normal" or "Warning". reason is a short CamelCase identifier
+// (e.g. "ConfigMapNotFound", "InvalidRuleSet"). This is a no-op if no event
+// recorder was configured on the Manager via WithEventRecorder.
+func (hc *HandlerContext) RecordEvent(eventType, reason, messageFmt string, args ...any) {
+	if hc.mgr.eventRecorder == nil {
+		return
+	}
+	hc.mgr.eventRecorder.Eventf(hc.primary, eventType, reason, messageFmt, args...)
 }
 
 // Filter narrows the set of resources returned by Fetch/FetchAll.

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,441 @@
+package makereconcile
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// fakeEventRecorder captures events for test assertions.
+type fakeEventRecorder struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	ObjectName string
+	EventType  string
+	Reason     string
+	Message    string
+}
+
+func (f *fakeEventRecorder) Event(object runtime.Object, eventtype string, reason string, message string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	name := ""
+	if co, ok := object.(metav1.ObjectMetaAccessor); ok {
+		name = co.GetObjectMeta().GetName()
+	}
+	f.events = append(f.events, recordedEvent{
+		ObjectName: name,
+		EventType:  eventtype,
+		Reason:     reason,
+		Message:    message,
+	})
+}
+
+func (f *fakeEventRecorder) Eventf(object runtime.Object, eventtype string, reason string, messageFmt string, args ...interface{}) {
+	f.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (f *fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype string, reason string, messageFmt string, args ...interface{}) {
+	f.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+// --- Option A: automatic framework events ---
+
+func TestEventAppliedOnSuccessfulApply(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cm.Name + "-deploy",
+				Namespace: cm.Namespace,
+			},
+		}
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(rec.events), rec.events)
+	}
+	ev := rec.events[0]
+	if ev.EventType != "Normal" {
+		t.Errorf("expected Normal event, got %q", ev.EventType)
+	}
+	if ev.Reason != "Applied" {
+		t.Errorf("expected reason Applied, got %q", ev.Reason)
+	}
+	if ev.ObjectName != "my-cm" {
+		t.Errorf("expected event on primary 'my-cm', got %q", ev.ObjectName)
+	}
+	if !strings.Contains(ev.Message, "Deployment") {
+		t.Errorf("expected message to contain output kind, got %q", ev.Message)
+	}
+}
+
+func TestEventDeletedOnStaleOutputRemoval(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	outputKey := mgr.reconcilers[0].ID() + "/" + primaryKey.String()
+
+	mgr.mu.Lock()
+	mgr.lastOutputs[outputKey] = map[types.NamespacedName]bool{
+		{Name: "my-cm-deploy", Namespace: "default"}: true,
+	}
+	mgr.mu.Unlock()
+
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+
+	var found bool
+	for _, ev := range rec.events {
+		if ev.Reason == "Deleted" && ev.EventType == "Normal" {
+			found = true
+			if ev.ObjectName != "my-cm" {
+				t.Errorf("expected event on primary 'my-cm', got %q", ev.ObjectName)
+			}
+			if !strings.Contains(ev.Message, "Deployment") {
+				t.Errorf("expected message to contain output kind, got %q", ev.Message)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected Deleted event, got events: %+v", rec.events)
+	}
+}
+
+func TestEventReconcileFailedOnStatusReconcilerError(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	fakeC := &fakeClient{statusPatchErr: fmt.Errorf("status patch refused")}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          fakeC,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	type cmStatus struct {
+		Ready bool `json:"ready"`
+	}
+	ReconcileStatus(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *cmStatus {
+		return &cmStatus{Ready: true}
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runStatusReconciler(context.Background(), mgr.statusReconcilers[0], primaryKey)
+
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(rec.events), rec.events)
+	}
+	ev := rec.events[0]
+	if ev.EventType != "Warning" {
+		t.Errorf("expected Warning event, got %q", ev.EventType)
+	}
+	if ev.Reason != "ReconcileFailed" {
+		t.Errorf("expected reason ReconcileFailed, got %q", ev.Reason)
+	}
+	if ev.ObjectName != "my-cm" {
+		t.Errorf("expected event on 'my-cm', got %q", ev.ObjectName)
+	}
+}
+
+func TestNoEventsWhenRecorderIsNil(t *testing.T) {
+	s := coreScheme()
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		// eventRecorder intentionally nil
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cm.Name + "-deploy", Namespace: cm.Namespace,
+			},
+		}
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+	// No panic — that's the assertion.
+}
+
+// --- Option B: per-reconciler RecordEvent ---
+
+func TestHandlerContextRecordEvent(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		hc.RecordEvent("Warning", "ConfigMapNotFound", "Referenced ConfigMap %s not found", "rules-cm")
+		return nil
+	})
+
+	r := mgr.reconcilers[0]
+	_, err := r.Reconcile(context.Background(), mgr, types.NamespacedName{Name: "my-cm", Namespace: "default"})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	// Find the user-emitted event (there should be exactly one since the
+	// reconciler returned nil so no apply/delete happens).
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event from RecordEvent, got %d: %+v", len(rec.events), rec.events)
+	}
+	ev := rec.events[0]
+	if ev.EventType != "Warning" {
+		t.Errorf("expected Warning, got %q", ev.EventType)
+	}
+	if ev.Reason != "ConfigMapNotFound" {
+		t.Errorf("expected reason ConfigMapNotFound, got %q", ev.Reason)
+	}
+	if ev.ObjectName != "my-cm" {
+		t.Errorf("expected event on primary 'my-cm', got %q", ev.ObjectName)
+	}
+	if !strings.Contains(ev.Message, "rules-cm") {
+		t.Errorf("expected message to contain 'rules-cm', got %q", ev.Message)
+	}
+}
+
+func TestHandlerContextRecordEventNilRecorder(t *testing.T) {
+	s := coreScheme()
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		// eventRecorder intentionally nil
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		hc.RecordEvent("Warning", "SomeReason", "some message")
+		return nil
+	})
+
+	r := mgr.reconcilers[0]
+	_, err := r.Reconcile(context.Background(), mgr, types.NamespacedName{Name: "my-cm", Namespace: "default"})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	// No panic — that's the assertion.
+}
+
+func TestRecordEventInStatusReconciler(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{
+			{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cm", Namespace: "default", UID: "uid-1",
+				},
+			},
+		},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	type cmStatus struct {
+		Ready bool `json:"ready"`
+	}
+	ReconcileStatus(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *cmStatus {
+		hc.RecordEvent("Normal", "StatusComputed", "Computed status for %s", cm.Name)
+		return &cmStatus{Ready: true}
+	})
+
+	sr := mgr.statusReconcilers[0]
+	err := sr.ReconcileStatus(context.Background(), mgr, types.NamespacedName{Name: "my-cm", Namespace: "default"})
+	if err != nil {
+		t.Fatalf("status reconcile error: %v", err)
+	}
+
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(rec.events), rec.events)
+	}
+	if rec.events[0].Reason != "StatusComputed" {
+		t.Errorf("expected reason StatusComputed, got %q", rec.events[0].Reason)
+	}
+	if rec.events[0].ObjectName != "my-cm" {
+		t.Errorf("expected event on 'my-cm', got %q", rec.events[0].ObjectName)
+	}
+}
+
+func TestReconcileFailedEventNotEmittedWhenPrimaryGone(t *testing.T) {
+	s := coreScheme()
+	rec := &fakeEventRecorder{}
+	fc := &fakeCache{
+		objects: map[types.NamespacedName]runtime.Object{},
+	}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	// Primary doesn't exist → reconcile fails, getPrimary returns nil → no event.
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0],
+		types.NamespacedName{Name: "gone", Namespace: "default"})
+
+	if len(rec.events) != 0 {
+		t.Errorf("expected 0 events when primary is gone (recordEvent is nil-safe), got %d: %+v",
+			len(rec.events), rec.events)
+	}
+}

--- a/examples/coraza/main.go
+++ b/examples/coraza/main.go
@@ -6,10 +6,14 @@ import (
 	"os"
 	"os/signal"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 
 	mr "github.com/aslakknutsen/make-reconcile"
 )
@@ -31,9 +35,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		log.Error("failed to create clientset", "error", err)
+		os.Exit(1)
+	}
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "coraza-operator"})
+
 	mgr, err := mr.NewManager(cfg, scheme,
 		mr.WithLogger(log),
 		mr.WithManagerID("coraza-operator"),
+		mr.WithEventRecorder(recorder),
 	)
 	if err != nil {
 		log.Error("failed to create manager", "error", err)

--- a/examples/coraza/register.go
+++ b/examples/coraza/register.go
@@ -30,7 +30,8 @@ func RegisterAll(mgr *mr.Manager) {
 	//
 	// Here, step 1 is the reconciler function. Steps 2-3 are handled by
 	// the framework (owner ref + SSA). Steps 4-5 are the status reconciler.
-	// Step 6 (events) has no equivalent — see analysis.
+	// Step 6 is now handled by the framework (automatic Applied/Deleted
+	// events via WithEventRecorder) plus custom events via RecordEvent.
 	mr.Reconcile(mgr, engines, WasmPluginReconciler)
 
 	// Engine -> status (conditions + matched gateways)
@@ -57,8 +58,11 @@ func RegisterAll(mgr *mr.Manager) {
 	//
 	// 1. Event recording (r.Recorder.Eventf):
 	//    The original fires k8s Events for ConfigMapNotFound, InvalidRuleSet,
-	//    WasmPluginCreated, etc. make-reconcile has no event recording hook.
-	//    Could be added as a callback/middleware on reconciler functions.
+	//    WasmPluginCreated, etc. The framework now handles this via two mechanisms:
+	//    - Automatic events: WithEventRecorder emits Applied/Deleted/ReconcileFailed
+	//      events without any code in the reconciler functions.
+	//    - Custom events: hc.RecordEvent("Warning", "ConfigMapNotFound", ...) in
+	//      reconciler functions for domain-specific events. See AggregatedRulesReconciler.
 	//
 	// 2. Driver dispatch (selectDriver):
 	//    The original switches on engine.Spec.Driver.Istio vs future drivers.

--- a/examples/coraza/rules.go
+++ b/examples/coraza/rules.go
@@ -36,11 +36,15 @@ func AggregatedRulesReconciler(configMaps *mr.Collection[*corev1.ConfigMap]) fun
 		for i, rule := range rs.Spec.Rules {
 			cm := mr.Fetch(hc, configMaps, mr.FilterName(rule.Name, rs.Namespace))
 			if cm == nil {
+				hc.RecordEvent("Warning", "ConfigMapNotFound",
+					"Referenced ConfigMap %s not found in namespace %s", rule.Name, rs.Namespace)
 				return nil
 			}
 
 			data, ok := cm.Data["rules"]
 			if !ok {
+				hc.RecordEvent("Warning", "InvalidRuleSet",
+					"ConfigMap %s missing 'rules' key", rule.Name)
 				return nil
 			}
 

--- a/fakecache_test.go
+++ b/fakecache_test.go
@@ -61,7 +61,8 @@ func (f *fakeCache) IndexField(ctx context.Context, obj client.Object, field str
 // It supports List (for gcOrphans) and tracks Delete calls.
 type fakeClient struct {
 	client.Client
-	statusPatches int
+	statusPatches  int
+	statusPatchErr error
 
 	// listObjects are returned by List, keyed by item GVK (not the "List" GVK).
 	listObjects map[schema.GroupVersionKind][]unstructured.Unstructured
@@ -126,7 +127,7 @@ func (f *fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts .
 
 func (f *fakeStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 	f.fc.statusPatches++
-	return nil
+	return f.fc.statusPatchErr
 }
 
 func (f *fakeStatusWriter) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {

--- a/manager.go
+++ b/manager.go
@@ -14,10 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	toolscache "k8s.io/client-go/tools/cache"
 )
 
 // Manager is the central coordinator. It holds the kubernetes client, cache,
@@ -38,8 +39,9 @@ type Manager struct {
 	watchPredicates   map[schema.GroupVersionKind][]EventPredicate
 	tracker           *dependencyTracker
 
-	resyncPeriod time.Duration
-	managerID    string
+	resyncPeriod  time.Duration
+	managerID     string
+	eventRecorder record.EventRecorder
 
 	// lastOutputs tracks which output resource keys were produced by each
 	// (reconciler, primary) pair on the last run. Used to detect deletions
@@ -65,6 +67,14 @@ func WithLogger(l *slog.Logger) ManagerOption {
 // don't interfere with each other. Default is "default".
 func WithManagerID(id string) ManagerOption {
 	return func(m *Manager) { m.managerID = id }
+}
+
+// WithEventRecorder sets the Kubernetes event recorder used to emit events
+// on primary resources. When set, the framework automatically emits events
+// for successful applies, stale output deletions, and reconciliation errors.
+// Reconciler functions can also emit custom events via HandlerContext.RecordEvent.
+func WithEventRecorder(recorder record.EventRecorder) ManagerOption {
+	return func(m *Manager) { m.eventRecorder = recorder }
 }
 
 // NewManager creates a new Manager from a rest.Config and scheme.
@@ -306,6 +316,9 @@ func (m *Manager) runSubReconciler(ctx context.Context, r subReconciler, primary
 			"primary", primaryKey,
 			"error", err,
 		)
+		m.recordEvent(m.getPrimary(ctx, r.PrimaryGVK(), primaryKey),
+			"Warning", "ReconcileFailed",
+			"Reconciler %s failed: %v", r.ID(), err)
 		return
 	}
 
@@ -331,6 +344,11 @@ func (m *Manager) runSubReconciler(ctx context.Context, r subReconciler, primary
 				"resource", onn,
 				"error", err,
 			)
+			m.recordEvent(primaryObj, "Warning", "ApplyFailed",
+				"Failed to apply %s %s: %v", r.OutputGVK().Kind, onn, err)
+		} else {
+			m.recordEvent(primaryObj, "Normal", "Applied",
+				"Applied %s %s", r.OutputGVK().Kind, onn)
 		}
 	}
 
@@ -359,6 +377,13 @@ func (m *Manager) runSubReconciler(ctx context.Context, r subReconciler, primary
 					"resource", prev,
 					"error", err,
 				)
+				m.recordEvent(m.getPrimary(ctx, r.PrimaryGVK(), primaryKey),
+					"Warning", "DeleteFailed",
+					"Failed to delete stale %s %s: %v", r.OutputGVK().Kind, prev, err)
+			} else {
+				m.recordEvent(m.getPrimary(ctx, r.PrimaryGVK(), primaryKey),
+					"Normal", "Deleted",
+					"Deleted stale %s %s", r.OutputGVK().Kind, prev)
 			}
 		}
 	}
@@ -386,7 +411,19 @@ func (m *Manager) runStatusReconciler(ctx context.Context, sr statusSubReconcile
 			"primary", primaryKey,
 			"error", err,
 		)
+		m.recordEvent(m.getPrimary(ctx, sr.PrimaryGVK(), primaryKey),
+			"Warning", "ReconcileFailed",
+			"Status reconciler %s failed: %v", sr.ID(), err)
 	}
+}
+
+// recordEvent emits a Kubernetes event on the given object if an event
+// recorder has been configured. Safe to call with a nil object or nil recorder.
+func (m *Manager) recordEvent(obj client.Object, eventType, reason, messageFmt string, args ...any) {
+	if m.eventRecorder == nil || obj == nil {
+		return
+	}
+	m.eventRecorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
 func (m *Manager) fullReconcile(ctx context.Context) {

--- a/reconciler.go
+++ b/reconciler.go
@@ -63,7 +63,7 @@ func (r *typedSubReconciler[P, T]) Reconcile(ctx context.Context, mgr *Manager, 
 		return nil, nil
 	}
 
-	hc := newHandlerContext(ctx, mgr)
+	hc := newHandlerContext(ctx, mgr, primary)
 	result := r.fn(hc, primary)
 
 	ref := reconcilerRef{ReconcilerID: r.id, PrimaryKey: primaryKey}
@@ -100,7 +100,7 @@ func (r *typedManySubReconciler[P, T]) Reconcile(ctx context.Context, mgr *Manag
 		return nil, nil
 	}
 
-	hc := newHandlerContext(ctx, mgr)
+	hc := newHandlerContext(ctx, mgr, primary)
 	results := r.fn(hc, primary)
 
 	ref := reconcilerRef{ReconcilerID: r.id, PrimaryKey: primaryKey}
@@ -224,7 +224,7 @@ func (r *typedStatusSubReconciler[P, S]) ReconcileStatus(ctx context.Context, mg
 		return nil
 	}
 
-	hc := newHandlerContext(ctx, mgr)
+	hc := newHandlerContext(ctx, mgr, primary)
 	status := r.fn(hc, primary)
 
 	ref := reconcilerRef{ReconcilerID: r.id, PrimaryKey: primaryKey}


### PR DESCRIPTION
## Summary

Implements both options from #2:

- **Option A (automatic events):** `WithEventRecorder(recorder)` on the Manager causes the framework to automatically emit `Normal/Applied`, `Normal/Deleted`, `Warning/ReconcileFailed`, `Warning/ApplyFailed`, and `Warning/DeleteFailed` events on the primary resource during reconciliation.
- **Option B (custom events):** `HandlerContext.RecordEvent(eventType, reason, messageFmt, args...)` lets reconciler functions emit domain-specific events (e.g. `ConfigMapNotFound`, `InvalidRuleSet`) on the primary being reconciled.

Both are no-ops when no event recorder is configured, so existing code is unaffected.

### Changes

- `manager.go`: Added `eventRecorder` field, `WithEventRecorder` option, `recordEvent` helper. Automatic event emission in `runSubReconciler` (apply, delete, error) and `runStatusReconciler` (error).
- `context.go`: Added `primary` field to `HandlerContext`, `RecordEvent` method. Updated `newHandlerContext` to accept primary.
- `reconciler.go`: Pass primary to `newHandlerContext` in all three reconciler types.
- `events_test.go`: Tests for automatic events (Applied, Deleted, ReconcileFailed), custom events via RecordEvent, nil-recorder safety, nil-primary safety.
- `fakecache_test.go`: Added `statusPatchErr` to `fakeClient` for testing status reconciler failures.
- `examples/coraza/`: Updated to demonstrate both mechanisms — `WithEventRecorder` in `main.go`, `RecordEvent` calls in `rules.go`, updated comments in `register.go`.

## Test plan

- [ ] Existing tests pass (no behavioral changes for callers without event recorder)
- [ ] `TestEventAppliedOnSuccessfulApply` — Applied event emitted after SSA
- [ ] `TestEventDeletedOnStaleOutputRemoval` — Deleted event emitted when output shrinks
- [ ] `TestEventReconcileFailedOnStatusReconcilerError` — Warning event on status reconciler failure
- [ ] `TestHandlerContextRecordEvent` — Custom events emitted on correct primary
- [ ] `TestHandlerContextRecordEventNilRecorder` — No panic when recorder is nil
- [ ] `TestReconcileFailedEventNotEmittedWhenPrimaryGone` — No event when primary doesn't exist

Closes #2

Made with [Cursor](https://cursor.com)