### PR TITLE
feat: gracefully handle missing CRDs at startup with automatic reconnection

### DIFF
--- a/fakecache_test.go
+++ b/fakecache_test.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
+	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -56,6 +60,92 @@ func (f *fakeCache) WaitForCacheSync(ctx context.Context) bool               { r
 func (f *fakeCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	return fmt.Errorf("not implemented")
 }
+
+// crdAwareCache extends fakeCache with GetInformer support for testing
+// pending watch behavior. GVKs listed in missingCRDs return a
+// NoKindMatchError from GetInformer; others succeed.
+type crdAwareCache struct {
+	fakeCache
+	scheme     *runtime.Scheme
+	mu         sync.Mutex
+	missingCRDs map[schema.GroupVersionKind]bool
+	handlers    map[schema.GroupVersionKind][]toolscache.ResourceEventHandler
+}
+
+func newCRDAwareCache(s *runtime.Scheme, objects map[types.NamespacedName]runtime.Object, missing ...schema.GroupVersionKind) *crdAwareCache {
+	m := make(map[schema.GroupVersionKind]bool)
+	for _, gvk := range missing {
+		m[gvk] = true
+	}
+	c := &crdAwareCache{
+		fakeCache:   fakeCache{objects: objects},
+		scheme:      s,
+		missingCRDs: m,
+		handlers:    make(map[schema.GroupVersionKind][]toolscache.ResourceEventHandler),
+	}
+	if c.fakeCache.objects == nil {
+		c.fakeCache.objects = make(map[types.NamespacedName]runtime.Object)
+	}
+	return c
+}
+
+func (c *crdAwareCache) GetInformer(ctx context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error) {
+	gvks, _, err := c.scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.missingCRDs[gvk] {
+		return nil, &meta.NoKindMatchError{
+			GroupKind: schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind},
+		}
+	}
+	return &fakeInformer{cache: c, gvk: gvk}, nil
+}
+
+func (c *crdAwareCache) SetCRDAvailable(gvk schema.GroupVersionKind) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.missingCRDs, gvk)
+}
+
+func (c *crdAwareCache) HandlerCount(gvk schema.GroupVersionKind) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.handlers[gvk])
+}
+
+// fakeInformer satisfies cache.Informer for testing.
+type fakeInformer struct {
+	cache *crdAwareCache
+	gvk   schema.GroupVersionKind
+}
+
+func (fi *fakeInformer) AddEventHandler(handler toolscache.ResourceEventHandler) (toolscache.ResourceEventHandlerRegistration, error) {
+	fi.cache.mu.Lock()
+	fi.cache.handlers[fi.gvk] = append(fi.cache.handlers[fi.gvk], handler)
+	fi.cache.mu.Unlock()
+	return nil, nil
+}
+
+func (fi *fakeInformer) AddEventHandlerWithResyncPeriod(handler toolscache.ResourceEventHandler, _ time.Duration) (toolscache.ResourceEventHandlerRegistration, error) {
+	return fi.AddEventHandler(handler)
+}
+
+func (fi *fakeInformer) AddEventHandlerWithOptions(handler toolscache.ResourceEventHandler, _ toolscache.HandlerOptions) (toolscache.ResourceEventHandlerRegistration, error) {
+	return fi.AddEventHandler(handler)
+}
+
+func (fi *fakeInformer) RemoveEventHandler(_ toolscache.ResourceEventHandlerRegistration) error {
+	return nil
+}
+
+func (fi *fakeInformer) AddIndexers(_ toolscache.Indexers) error { return nil }
+func (fi *fakeInformer) HasSynced() bool                        { return true }
+func (fi *fakeInformer) IsStopped() bool                        { return false }
 
 // fakeClient implements client.Client with no-op writes for testing.
 // It supports List (for gcOrphans) and tracks Delete calls.

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/manager.go
+++ b/manager.go
@@ -47,6 +47,11 @@ type Manager struct {
 	// (reconciler, primary) pair on the last run. Used to detect deletions
 	// when the set of outputs shrinks.
 	lastOutputs map[string]map[types.NamespacedName]bool
+
+	// pendingWatches holds GVKs whose CRDs were not available at startup.
+	// A background goroutine retries registration periodically.
+	pendingWatches             []schema.GroupVersionKind
+	pendingWatchRetryInterval  time.Duration
 }
 
 // ManagerOption configures a Manager.
@@ -67,6 +72,12 @@ func WithLogger(l *slog.Logger) ManagerOption {
 // don't interfere with each other. Default is "default".
 func WithManagerID(id string) ManagerOption {
 	return func(m *Manager) { m.managerID = id }
+}
+
+// WithPendingWatchRetryInterval sets how often the manager retries registering
+// watches for GVKs whose CRDs were not available at startup. Default is 10s.
+func WithPendingWatchRetryInterval(d time.Duration) ManagerOption {
+	return func(m *Manager) { m.pendingWatchRetryInterval = d }
 }
 
 // WithEventRecorder sets the Kubernetes event recorder used to emit events
@@ -136,11 +147,23 @@ func NewManagerForTest(scheme *runtime.Scheme) *Manager {
 
 // Start begins watching all registered GVKs, routing events to sub-reconcilers,
 // and running periodic full resyncs. Blocks until ctx is cancelled.
+//
+// If a watched GVK's CRD is not yet installed on the cluster, Start does not
+// fail. Instead it skips that watch and retries periodically in the background.
+// When the CRD becomes available the handler is registered and a full reconcile
+// runs so that all reconcilers see the newly available resources.
 func (m *Manager) Start(ctx context.Context) error {
 	// Register informer event handlers before starting the cache.
+	// GVKs whose CRD is missing are collected for background retry.
+	var pending []schema.GroupVersionKind
 	for gvk := range m.watchedGVKs {
-		if err := m.registerHandler(ctx, gvk); err != nil {
+		registered, err := m.registerHandler(ctx, gvk)
+		if err != nil {
 			return fmt.Errorf("register handler for %v: %w", gvk, err)
+		}
+		if !registered {
+			m.log.Warn("CRD not found, will retry periodically", "gvk", gvk)
+			pending = append(pending, gvk)
 		}
 	}
 
@@ -159,6 +182,14 @@ func (m *Manager) Start(ctx context.Context) error {
 	m.fullReconcile(ctx)
 	m.gcOrphans(ctx)
 
+	// Start background retry for GVKs whose CRDs were missing at startup.
+	if len(pending) > 0 {
+		m.mu.Lock()
+		m.pendingWatches = pending
+		m.mu.Unlock()
+		go m.retryPendingWatches(ctx)
+	}
+
 	// Periodic full resync.
 	ticker := time.NewTicker(m.resyncPeriod)
 	defer ticker.Stop()
@@ -174,24 +205,95 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 }
 
-func (m *Manager) registerHandler(ctx context.Context, gvk schema.GroupVersionKind) error {
+// PendingWatchCount returns the number of GVKs still awaiting CRD availability.
+func (m *Manager) PendingWatchCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.pendingWatches)
+}
+
+// retryPendingWatches periodically attempts to register event handlers for
+// GVKs whose CRDs were missing at startup. When a CRD becomes available the
+// handler is registered, the cache is synced, and a full reconcile runs.
+// Exits when all pending watches are resolved or the context is cancelled.
+func (m *Manager) retryPendingWatches(ctx context.Context) {
+	interval := m.pendingWatchRetryInterval
+	if interval == 0 {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.mu.Lock()
+			pending := make([]schema.GroupVersionKind, len(m.pendingWatches))
+			copy(pending, m.pendingWatches)
+			m.mu.Unlock()
+
+			if len(pending) == 0 {
+				return
+			}
+
+			var stillPending []schema.GroupVersionKind
+			resolved := false
+			for _, gvk := range pending {
+				registered, err := m.registerHandler(ctx, gvk)
+				if err != nil {
+					m.log.Error("retry register handler failed", "gvk", gvk, "error", err)
+					stillPending = append(stillPending, gvk)
+					continue
+				}
+				if !registered {
+					stillPending = append(stillPending, gvk)
+					continue
+				}
+				m.log.Info("CRD now available, watch registered", "gvk", gvk)
+				resolved = true
+			}
+
+			m.mu.Lock()
+			m.pendingWatches = stillPending
+			m.mu.Unlock()
+
+			if resolved {
+				if !m.cache.WaitForCacheSync(ctx) {
+					m.log.Error("cache sync failed after registering pending watch")
+					continue
+				}
+				m.fullReconcile(ctx)
+			}
+		}
+	}
+}
+
+// registerHandler sets up an informer event handler for the given GVK.
+// Returns (true, nil) on success, (false, nil) when the CRD is not yet
+// installed on the cluster, or (false, err) for other failures.
+func (m *Manager) registerHandler(ctx context.Context, gvk schema.GroupVersionKind) (bool, error) {
 	obj, err := m.scheme.New(gvk)
 	if err != nil {
-		return fmt.Errorf("scheme.New(%v): %w", gvk, err)
+		return false, fmt.Errorf("scheme.New(%v): %w", gvk, err)
 	}
 	cObj, ok := obj.(client.Object)
 	if !ok {
-		return fmt.Errorf("type for %v does not implement client.Object", gvk)
+		return false, fmt.Errorf("type for %v does not implement client.Object", gvk)
 	}
 
 	informer, err := m.cache.GetInformer(ctx, cObj)
 	if err != nil {
-		return fmt.Errorf("get informer for %v: %w", gvk, err)
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get informer for %v: %w", gvk, err)
 	}
 
 	handler := &eventHandler{mgr: m, gvk: gvk, predicates: m.watchPredicates[gvk]}
 	informer.AddEventHandler(handler)
-	return nil
+	return true, nil
 }
 
 // eventHandler routes informer events to the appropriate sub-reconcilers.

--- a/pendingwatch_test.go
+++ b/pendingwatch_test.go
@@ -1,0 +1,256 @@
+package makereconcile
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRegisterHandlerSucceeds(t *testing.T) {
+	s := coreScheme()
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	fc := newCRDAwareCache(s, nil)
+
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	registered, err := mgr.registerHandler(context.Background(), cmGVK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !registered {
+		t.Error("expected handler to be registered")
+	}
+	if fc.HandlerCount(cmGVK) != 1 {
+		t.Errorf("expected 1 handler registered, got %d", fc.HandlerCount(cmGVK))
+	}
+}
+
+func TestRegisterHandlerNoMatchReturnsFalse(t *testing.T) {
+	s := coreScheme()
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	fc := newCRDAwareCache(s, nil, cmGVK)
+
+	mgr := &Manager{
+		scheme:          s,
+		cache:           fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	registered, err := mgr.registerHandler(context.Background(), cmGVK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if registered {
+		t.Error("expected handler NOT to be registered when CRD is missing")
+	}
+	if fc.HandlerCount(cmGVK) != 0 {
+		t.Errorf("expected 0 handlers, got %d", fc.HandlerCount(cmGVK))
+	}
+}
+
+func TestStartContinuesWithMissingCRD(t *testing.T) {
+	s := coreScheme()
+	deployGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	fc := newCRDAwareCache(s, nil, deployGVK)
+
+	mgr := &Manager{
+		scheme:                    s,
+		cache:                     fc,
+		client:                    &fakeClient{},
+		log:                       slog.Default(),
+		watchedGVKs:               make(map[schema.GroupVersionKind]bool),
+		watchPredicates:           make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:                   newDependencyTracker(),
+		managerID:                 "default",
+		lastOutputs:               make(map[string]map[types.NamespacedName]bool),
+		resyncPeriod:              time.Hour,
+		pendingWatchRetryInterval: time.Hour,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+
+	// Give Start time to proceed past handler registration and cache sync.
+	time.Sleep(100 * time.Millisecond)
+
+	if mgr.PendingWatchCount() != 1 {
+		t.Errorf("expected 1 pending watch, got %d", mgr.PendingWatchCount())
+	}
+
+	// ConfigMap handler should be registered since its CRD is available.
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	if fc.HandlerCount(cmGVK) != 1 {
+		t.Errorf("expected ConfigMap handler registered, got %d", fc.HandlerCount(cmGVK))
+	}
+
+	// Deployment handler should NOT be registered.
+	if fc.HandlerCount(deployGVK) != 0 {
+		t.Errorf("expected no Deployment handler, got %d", fc.HandlerCount(deployGVK))
+	}
+
+	cancel()
+	<-errCh
+}
+
+func TestRetryPendingWatchesResolves(t *testing.T) {
+	s := coreScheme()
+	deployGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	fc := newCRDAwareCache(s, map[types.NamespacedName]runtime.Object{
+		{Name: "my-cm", Namespace: "default"}: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", UID: "uid-1"},
+		},
+	}, deployGVK)
+
+	mgr := &Manager{
+		scheme:                    s,
+		cache:                     fc,
+		client:                    &fakeClient{},
+		log:                       slog.Default(),
+		watchedGVKs:               make(map[schema.GroupVersionKind]bool),
+		watchPredicates:           make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:                   newDependencyTracker(),
+		managerID:                 "default",
+		lastOutputs:               make(map[string]map[types.NamespacedName]bool),
+		resyncPeriod:              time.Hour,
+		pendingWatchRetryInterval: 50 * time.Millisecond,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	_ = Watch[*appsv1.Deployment](mgr)
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+
+	// Wait for Start to complete initial setup.
+	time.Sleep(100 * time.Millisecond)
+
+	if mgr.PendingWatchCount() != 1 {
+		t.Fatalf("expected 1 pending watch, got %d", mgr.PendingWatchCount())
+	}
+	if fc.HandlerCount(deployGVK) != 0 {
+		t.Fatalf("Deployment handler should not be registered yet")
+	}
+
+	// ConfigMap handler should already be registered.
+	if fc.HandlerCount(cmGVK) != 1 {
+		t.Fatalf("expected ConfigMap handler, got %d", fc.HandlerCount(cmGVK))
+	}
+
+	// "Install" the CRD.
+	fc.SetCRDAvailable(deployGVK)
+
+	// Wait for retry to pick it up.
+	time.Sleep(200 * time.Millisecond)
+
+	if mgr.PendingWatchCount() != 0 {
+		t.Errorf("expected 0 pending watches after CRD available, got %d", mgr.PendingWatchCount())
+	}
+	if fc.HandlerCount(deployGVK) != 1 {
+		t.Errorf("expected Deployment handler registered after CRD available, got %d", fc.HandlerCount(deployGVK))
+	}
+
+	cancel()
+	<-errCh
+}
+
+func TestRetryPendingWatchesStopsWhenAllResolved(t *testing.T) {
+	s := coreScheme()
+	deployGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+	fc := newCRDAwareCache(s, nil, deployGVK)
+
+	mgr := &Manager{
+		scheme:                    s,
+		cache:                     fc,
+		client:                    &fakeClient{},
+		log:                       slog.Default(),
+		watchedGVKs:               map[schema.GroupVersionKind]bool{deployGVK: true},
+		watchPredicates:           make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:                   newDependencyTracker(),
+		managerID:                 "default",
+		lastOutputs:               make(map[string]map[types.NamespacedName]bool),
+		pendingWatchRetryInterval: 20 * time.Millisecond,
+		pendingWatches:            []schema.GroupVersionKind{deployGVK},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Make the CRD available immediately.
+	fc.SetCRDAvailable(deployGVK)
+
+	done := make(chan struct{})
+	go func() {
+		mgr.retryPendingWatches(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// retryPendingWatches exited because all watches resolved.
+	case <-ctx.Done():
+		t.Fatal("retryPendingWatches did not exit after all watches resolved")
+	}
+
+	if mgr.PendingWatchCount() != 0 {
+		t.Errorf("expected 0 pending watches, got %d", mgr.PendingWatchCount())
+	}
+}
+
+func TestPendingWatchCountZeroByDefault(t *testing.T) {
+	mgr := &Manager{}
+	if mgr.PendingWatchCount() != 0 {
+		t.Errorf("expected 0 pending watches on new manager, got %d", mgr.PendingWatchCount())
+	}
+}
+
+func TestWithPendingWatchRetryIntervalOption(t *testing.T) {
+	mgr := &Manager{}
+	opt := WithPendingWatchRetryInterval(42 * time.Second)
+	opt(mgr)
+	if mgr.pendingWatchRetryInterval != 42*time.Second {
+		t.Errorf("expected 42s, got %v", mgr.pendingWatchRetryInterval)
+	}
+}


### PR DESCRIPTION
## Summary

- When a watched GVK's CRD is not installed on the cluster, `Start` no longer fails. It skips that watch, logs a warning, and retries periodically in a background goroutine.
- When the CRD becomes available the informer event handler is registered, the cache syncs, and a full reconcile runs so all reconcilers see the newly available resources.
- Adds `WithPendingWatchRetryInterval` option (default 10s) and `PendingWatchCount()` for observability.

## Design

`registerHandler` now returns `(bool, error)` — `(false, nil)` means the CRD is not yet available (detected via `meta.IsNoMatchError`). `Start` collects these pending GVKs and launches `retryPendingWatches` which ticks on the configured interval. When a CRD appears, the handler is registered, `WaitForCacheSync` is called for the new informer, and `fullReconcile` runs.

Reconcilers that `Fetch` from a not-yet-watched collection get zero results until the CRD appears. This is the correct behavior for optional dependencies.

## Test plan

- [x] `TestRegisterHandlerSucceeds` — handler registered when CRD exists
- [x] `TestRegisterHandlerNoMatchReturnsFalse` — returns (false, nil) for missing CRD
- [x] `TestStartContinuesWithMissingCRD` — Start does not fail, queues pending watch
- [x] `TestRetryPendingWatchesResolves` — pending watch resolves when CRD appears
- [x] `TestRetryPendingWatchesStopsWhenAllResolved` — goroutine exits when done
- [x] `TestPendingWatchCountZeroByDefault` — zero count on new manager
- [x] `TestWithPendingWatchRetryIntervalOption` — option configures interval
- [x] All 42 existing tests continue to pass

Closes #3

Made with [Cursor](https://cursor.com)