### PR TITLE
Evaluate istio-workspace (issue #8)

### DIFF
--- a/examples/istio-workspace/README.md
+++ b/examples/istio-workspace/README.md
@@ -1,0 +1,94 @@
+# istio-workspace evaluation
+
+Analysis of [istio-workspace](https://github.com/maistra/istio-workspace) controller patterns against make-reconcile.
+
+## What istio-workspace does
+
+istio-workspace manages `Session` CRDs that enable developers to route traffic to modified versions of services in an Istio mesh. When a developer creates a Session targeting a Deployment:
+
+1. **Locate** the target Deployment, its Services, VirtualServices, DestinationRules, and connected Gateways
+2. **Clone** the Deployment with modified labels/image
+3. **Create** a new DestinationRule subset pointing to the clone
+4. **Mutate** existing VirtualServices to add header-based routing rules
+5. **Mutate** existing Gateways to add session-prefixed hostnames
+6. On deletion, **revert** all mutations and delete created resources
+
+## Architecture pattern
+
+The controller uses a **Locator → Validator → Modificator** pipeline:
+
+- **Locators** discover existing cluster resources by following relationships (Deployment → Service → VirtualService → Gateway)
+- **Validators** check preconditions (target found, VirtualService exists, DestinationRule exists)
+- **Modificators** create new resources or mutate existing ones
+
+Data flows through a shared `LocatorStore` within a single Reconcile call. Each Locator adds entries that subsequent Locators and Modificators read.
+
+## What fits
+
+~30% of the controller logic maps to make-reconcile.
+
+### Deployment cloning (fits well)
+
+Session → cloned Deployments is a clean 1:N mapping. Fetch the original Deployment, transform it, return the clones. `nil`-means-delete handles cleanup when Refs are removed. The original's template engine is just Go code inside the reconciler.
+
+### DestinationRule creation (fits well)
+
+Session → session-scoped DestinationRules. The original creates a new DR rather than mutating the existing one, so this maps directly to ReconcileMany.
+
+### Gateway-connected VirtualService creation (partial fit)
+
+For VirtualServices connected to a Gateway, the original creates a new VS (not mutating the existing one). This part maps to ReconcileMany. But locating which VirtualServices are gateway-connected requires FetchAll + manual filtering.
+
+### Status computation (partial fit)
+
+The aggregate success/failure state can be a ReconcileStatus. But progressive status updates (the original calls Status().Update() ~10 times per reconcile) are lost.
+
+## What doesn't fit
+
+~70% of the controller logic conflicts with make-reconcile's model.
+
+### VirtualService mutation (fundamental mismatch)
+
+The core routing mechanism adds an HTTP route with a header match to an **existing** VirtualService the controller does not own. SSA would overwrite the entire VirtualService, destroying routes from other controllers. This needs a "foreign resource patch" primitive — apply specific fields without owning the whole resource.
+
+### Gateway host injection (fundamental mismatch)
+
+Same problem. Adding `session.app.example.com` to an existing Gateway's server hosts is a partial mutation of a shared resource.
+
+### Revert semantics (fundamental mismatch)
+
+On deletion, the controller removes the route it added to the VirtualService and the host it added to the Gateway. make-reconcile's deletion model is "delete the output resource", not "undo a partial mutation". The cloned Deployment and session DR are handled fine, but the VirtualService and Gateway reverts have no framework equivalent.
+
+### Dynamic discovery chain (poor fit)
+
+The Locator chain follows relationships: Deployment → Service (by label selector match) → VirtualService (by hostname) → Gateway (by reference). Each step uses the previous step's output. Fetch can't express "find Services whose .spec.selector matches these labels" — you need FetchAll + iterate, which creates broad dependencies and loses precision.
+
+### Multi-Session shared resources (mismatch)
+
+Multiple Sessions can target the same Deployment and add routes to the same VirtualService. The original uses annotation-based ref markers for multi-owner tracking. make-reconcile uses OwnerReferences (single owner, GC semantics) — deleting one Session could GC resources still needed by another.
+
+### Progressive status updates (limitation)
+
+The original updates status after each pipeline step. make-reconcile runs ReconcileStatus once after all outputs. Users lose visibility into intermediate states.
+
+### Validation gating (no equivalent)
+
+The original skips modification if validation fails. make-reconcile sub-reconcilers are independent — no way to gate one reconciler on another's success.
+
+## New features that would help
+
+1. **Foreign resource patch**: Apply specific fields on unowned resources with scoped SSA field managers. Generalizes the "foreign resource status" roadmap item to arbitrary spec fields.
+
+2. **Finalizer management with custom cleanup**: Run user-defined cleanup on primary deletion instead of just deleting outputs. Already on the roadmap.
+
+3. **Multi-owner tracking**: Track multiple primaries that contribute to the same output resource without OwnerReference GC semantics.
+
+4. **Rich Fetch predicates**: Support queries like "resources whose .spec.selector matches these labels" beyond name/namespace/label filters.
+
+## Verdict
+
+istio-workspace is a **poor fit** for make-reconcile in its current form. The controller's core pattern — discover existing resources via a chain, mutate them partially, then revert mutations on cleanup — is fundamentally at odds with the "return desired state for resources you own" model.
+
+The mismatch is structural, not incidental. istio-workspace is a **mutation controller** (modify what exists) while make-reconcile is a **desired-state controller** (declare what should exist). These are different reconciliation paradigms.
+
+The ~30% that fits (Deployment cloning, DR creation) works well and is cleaner than the original. But the ~70% that doesn't fit is the actual value of the controller — the traffic routing logic.

--- a/examples/istio-workspace/deployment.go
+++ b/examples/istio-workspace/deployment.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mr "github.com/aslakknutsen/make-reconcile"
+)
+
+// ClonedDeploymentReconciler produces a cloned Deployment for each Session Ref.
+//
+// This is the part that maps best to make-reconcile. The original controller's
+// DeploymentModificator clones the target Deployment with a modified name,
+// labels, and image. Here we Fetch the original and return the clone.
+//
+// The original uses a template engine to transform the Deployment JSON.
+// That logic could live inside this function, but the template engine's
+// imperative patching (arbitrary JSON transforms) doesn't have a
+// make-reconcile equivalent — it's just Go code in the reconciler body.
+func ClonedDeploymentReconciler(
+	deployments *mr.Collection[*appsv1.Deployment],
+) func(*mr.HandlerContext, *Session) []appsv1.Deployment {
+	return func(hc *mr.HandlerContext, session *Session) []appsv1.Deployment {
+		route := resolveRoute(session)
+		var clones []appsv1.Deployment
+
+		for _, ref := range session.Spec.Refs {
+			original := mr.Fetch(hc, deployments,
+				mr.FilterName(ref.Name, session.Namespace))
+			if original == nil {
+				continue
+			}
+
+			cloneName := original.Name + "-" + session.Name
+			version := cloneName
+
+			podLabels := copyLabels(original.Spec.Template.Labels)
+			podLabels["version"] = version
+			podLabels["ike.session"] = session.Name
+
+			clone := appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cloneName,
+					Namespace: session.Namespace,
+					Labels: map[string]string{
+						"ike.session": session.Name,
+						"ike.ref":     ref.Name,
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: original.Spec.Replicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: podLabels,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+						Spec:       *original.Spec.Template.Spec.DeepCopy(),
+					},
+				},
+			}
+
+			if image, ok := ref.Args["image"]; ok && len(clone.Spec.Template.Spec.Containers) > 0 {
+				clone.Spec.Template.Spec.Containers[0].Image = image
+			}
+
+			_ = route // route is used by VirtualService reconcilers, not Deployment
+			clones = append(clones, clone)
+		}
+
+		return clones
+	}
+}
+
+func copyLabels(src map[string]string) map[string]string {
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}

--- a/examples/istio-workspace/destinationrule.go
+++ b/examples/istio-workspace/destinationrule.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mr "github.com/aslakknutsen/make-reconcile"
+)
+
+// SessionDestinationRuleReconciler creates a DestinationRule for each Session
+// Ref, pointing to the cloned Deployment's pod version label.
+//
+// This maps reasonably well to make-reconcile. The original controller's
+// DestinationRuleModificator creates a new DR (not mutating the existing one)
+// with a single subset for the session version. Here we do the same via Fetch
+// on the existing DR to extract the TrafficPolicy, then return a new DR.
+//
+// The original locates the DR by matching the service hostname against
+// DR.spec.host — a query that Fetch can't express directly. We approximate
+// by fetching all DRs in the namespace and filtering manually.
+func SessionDestinationRuleReconciler(
+	destinationRules *mr.Collection[*DestinationRule],
+) func(*mr.HandlerContext, *Session) []DestinationRule {
+	return func(hc *mr.HandlerContext, session *Session) []DestinationRule {
+		allDRs := mr.FetchAll(hc, destinationRules,
+			mr.FilterNamespace(session.Namespace))
+
+		var results []DestinationRule
+
+		for _, ref := range session.Spec.Refs {
+			version := ref.Name + "-" + session.Name
+			hostName := ref.Name + "." + session.Namespace + ".svc.cluster.local"
+
+			var matchedDR *DestinationRule
+			for i := range allDRs {
+				if allDRs[i].Spec.Host == hostName || allDRs[i].Spec.Host == ref.Name {
+					matchedDR = allDRs[i]
+					break
+				}
+			}
+			if matchedDR == nil {
+				continue
+			}
+
+			results = append(results, DestinationRule{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.istio.io/v1alpha3",
+					Kind:       "DestinationRule",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dr-" + ref.Name + "-" + session.Name,
+					Namespace: session.Namespace,
+				},
+				Spec: DestinationRuleSpec{
+					Host: matchedDR.Spec.Host,
+					Subsets: []Subset{{
+						Name:   version,
+						Labels: map[string]string{"version": version},
+					}},
+				},
+			})
+		}
+
+		return results
+	}
+}

--- a/examples/istio-workspace/main.go
+++ b/examples/istio-workspace/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+
+	mr "github.com/aslakknutsen/make-reconcile"
+)
+
+func main() {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	AddToScheme(scheme)
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = os.Getenv("HOME") + "/.kube/config"
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		log.Error("failed to build kubeconfig", "error", err)
+		os.Exit(1)
+	}
+
+	mgr, err := mr.NewManager(cfg, scheme,
+		mr.WithLogger(log),
+		mr.WithManagerID("istio-workspace"),
+	)
+	if err != nil {
+		log.Error("failed to create manager", "error", err)
+		os.Exit(1)
+	}
+
+	RegisterAll(mgr)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	log.Info("starting istio-workspace controller")
+	if err := mgr.Start(ctx); err != nil {
+		log.Error("manager exited with error", "error", err)
+		os.Exit(1)
+	}
+}
+
+// Placeholder so the example compiles. The real controller would use
+// appsv1.Deployment from k8s.io/api/apps/v1 directly. We import corev1
+// here only to satisfy the scheme registration.
+var _ = corev1.Pod{}

--- a/examples/istio-workspace/register.go
+++ b/examples/istio-workspace/register.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	mr "github.com/aslakknutsen/make-reconcile"
+)
+
+func RegisterAll(mgr *mr.Manager) {
+	sessions := mr.Watch[*Session](mgr, mr.WithGenerationChanged())
+
+	deployments := mr.Watch[*appsv1.Deployment](mgr)
+	destinationRules := mr.Watch[*DestinationRule](mgr)
+	virtualServices := mr.Watch[*VirtualService](mgr)
+
+	// --- What CAN be modeled ---
+	//
+	// Session → cloned Deployments (one per Ref).
+	// The original clones the target Deployment with modified labels and
+	// image. Fetch on the original Deployment creates a dependency so
+	// changes to it trigger re-cloning. nil-means-delete handles cleanup
+	// when a Ref is removed from the Session.
+	mr.ReconcileMany(mgr, sessions, ClonedDeploymentReconciler(deployments))
+
+	// Session → DestinationRules (one per Ref).
+	// The original creates a new DR with a subset pointing to the cloned
+	// pod version. This is a clean 1:N mapping.
+	mr.ReconcileMany(mgr, sessions, SessionDestinationRuleReconciler(destinationRules))
+
+	// Session → status (aggregate readiness of cloned resources).
+	mr.ReconcileStatus(mgr, sessions, SessionStatusReconciler(deployments, destinationRules))
+
+	// --- What CANNOT be modeled ---
+	//
+	// These are the core operations of istio-workspace that don't fit.
+	// They are listed here to make the gaps explicit.
+	//
+	// 1. VirtualService mutation (the main traffic routing mechanism):
+	//
+	//    The original adds a header-match HTTP route to existing
+	//    VirtualServices. This is a partial mutation of a resource the
+	//    controller does not own. make-reconcile's SSA model would
+	//    overwrite the entire VirtualService spec, destroying routes
+	//    managed by other controllers or users.
+	//
+	//    The framework would need a "foreign resource patch" primitive
+	//    that applies only specific fields via a scoped field manager.
+	//    This is related to the "foreign resource status" roadmap item
+	//    but generalized to arbitrary spec fields.
+	//
+	//    Attempted workaround: create a separate VirtualService per
+	//    session. This works for gateway-connected VS (the original does
+	//    this too) but not for mesh-internal routing where you must modify
+	//    the existing VS to insert the header-match rule ahead of the
+	//    default route.
+	//
+	_ = virtualServices // watched but unused — can't mutate existing VS
+
+	// 2. Gateway host injection:
+	//
+	//    The original adds session-prefixed hostnames (e.g. "mysession.app.example.com")
+	//    to existing Gateway .spec.servers[].hosts. Same problem as #1:
+	//    partial mutation of an unowned resource. SSA would clobber other hosts.
+	//
+	// 3. Finalizer-based revert (not delete):
+	//
+	//    On Session deletion, the original doesn't just delete created
+	//    resources — it reverts mutations. The added VirtualService route
+	//    is removed. The added Gateway host is removed. make-reconcile's
+	//    deletion model is "delete the output resource entirely", which
+	//    works for the cloned Deployment and session DR but not for
+	//    reverting partial mutations on shared resources.
+	//
+	//    The framework would need finalizer management with custom cleanup
+	//    callbacks. This is already on the roadmap.
+	//
+	// 4. Dynamic resource discovery chain:
+	//
+	//    The original's Locator pipeline discovers resources by following
+	//    relationships:
+	//      Deployment → (label match) → Service → (hostname) → VirtualService → (gateway ref) → Gateway
+	//
+	//    Each step uses the output of the previous step. Fetch can look up
+	//    resources by name/namespace/label, but "find Services whose
+	//    .spec.selector matches these labels" requires FetchAll + manual
+	//    filter. The chain works but is verbose and loses the framework's
+	//    ability to create precise dependency keys.
+	//
+	// 5. Service discovery by selector matching:
+	//
+	//    ServiceLocator finds Services whose selector matches the target
+	//    Deployment's pod template labels. This is a reverse label match
+	//    (the Service selects the Deployment, not the other way around).
+	//    Fetch/FetchAll can filter by the resource's own labels, not by
+	//    the resource's selector field. You'd need FetchAll + iterate.
+	//
+	// 6. Template engine for Deployment transformation:
+	//
+	//    The original uses a pluggable template engine (Go templates or
+	//    JSON patches loaded from files) to transform the cloned
+	//    Deployment. This is pure business logic that works inside the
+	//    reconciler function, but the "load templates from a file path"
+	//    pattern has no framework equivalent. It's just code you'd write
+	//    in the reconciler body.
+	//
+	// 7. Progressive status updates:
+	//
+	//    The original calls Status().Update() after each locator,
+	//    validator, and modificator step — sometimes 10+ times in one
+	//    Reconcile call. make-reconcile runs ReconcileStatus once after
+	//    all output reconcilers. The user sees the final state, not the
+	//    progression. For debugging, this is a meaningful loss.
+	//
+	// 8. Validation as a gate:
+	//
+	//    The original runs validators between location and modification.
+	//    If validation fails (e.g. no DestinationRule found), modification
+	//    is skipped entirely. make-reconcile has no inter-reconciler
+	//    gating — each sub-reconciler runs independently. You could check
+	//    preconditions inside the reconciler and return nil, but there's no
+	//    way to prevent other reconcilers from running.
+	//
+	// 9. Multi-Session coordination on shared resources:
+	//
+	//    Multiple Sessions can target the same Deployment. The original
+	//    uses annotation-based ref markers to track which Session owns
+	//    which mutation. make-reconcile uses OwnerReferences which imply
+	//    single ownership and trigger GC — wrong for shared resources
+	//    where multiple Sessions add routes to the same VirtualService.
+}

--- a/examples/istio-workspace/status.go
+++ b/examples/istio-workspace/status.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	mr "github.com/aslakknutsen/make-reconcile"
+)
+
+// SessionStatusReconciler computes Session status from the state of cloned
+// Deployments and session DestinationRules.
+//
+// The original controller updates status progressively during the
+// locate→validate→modify pipeline, emitting multiple Status().Update calls.
+// make-reconcile runs status reconcilers once after all output reconcilers,
+// so we compute the aggregate here.
+func SessionStatusReconciler(
+	deployments *mr.Collection[*appsv1.Deployment],
+	destinationRules *mr.Collection[*DestinationRule],
+) func(*mr.HandlerContext, *Session) *SessionStatus {
+	return func(hc *mr.HandlerContext, session *Session) *SessionStatus {
+		route := resolveRoute(session)
+
+		var refNames []string
+		var strategies []string
+		allReady := true
+
+		for _, ref := range session.Spec.Refs {
+			refNames = append(refNames, ref.Name)
+			if ref.Strategy != "" {
+				strategies = append(strategies, ref.Strategy)
+			}
+
+			cloneName := ref.Name + "-" + session.Name
+			deploy := mr.Fetch(hc, deployments,
+				mr.FilterName(cloneName, session.Namespace))
+			if deploy == nil {
+				allReady = false
+				continue
+			}
+			if deploy.Status.ReadyReplicas == 0 {
+				allReady = false
+			}
+
+			drName := "dr-" + ref.Name + "-" + session.Name
+			dr := mr.Fetch(hc, destinationRules,
+				mr.FilterName(drName, session.Namespace))
+			if dr == nil {
+				allReady = false
+			}
+		}
+
+		state := "Processing"
+		if allReady && len(session.Spec.Refs) > 0 {
+			state = "Success"
+		}
+
+		return &SessionStatus{
+			State:      state,
+			Route:      &route,
+			RefNames:   refNames,
+			Strategies: strategies,
+		}
+	}
+}
+
+func resolveRoute(session *Session) Route {
+	if session.Spec.Route.Type != "" {
+		return session.Spec.Route
+	}
+	return Route{
+		Type:  "header",
+		Name:  "x-workspace-route",
+		Value: session.Name,
+	}
+}

--- a/examples/istio-workspace/types.go
+++ b/examples/istio-workspace/types.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Simplified types modeling the real istio-workspace CRDs and Istio networking types.
+// In production these come from:
+//   github.com/maistra/istio-workspace/api/maistra/v1alpha1
+//   istio.io/client-go/pkg/apis/networking/v1alpha3
+
+var (
+	WorkspaceGV  = schema.GroupVersion{Group: "workspace.maistra.io", Version: "v1alpha1"}
+	IstioNetGV   = schema.GroupVersion{Group: "networking.istio.io", Version: "v1alpha3"}
+)
+
+// --- Session ---
+
+type Session struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              SessionSpec   `json:"spec,omitempty"`
+	Status            SessionStatus `json:"status,omitempty"`
+}
+
+type SessionSpec struct {
+	Route Route `json:"route,omitempty"`
+	Refs  []Ref `json:"ref,omitempty"`
+}
+
+type Ref struct {
+	Name     string            `json:"name,omitempty"`
+	Strategy string            `json:"strategy,omitempty"`
+	Args     map[string]string `json:"args,omitempty"`
+}
+
+type Route struct {
+	Type  string `json:"type,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+type SessionStatus struct {
+	State      string   `json:"state,omitempty"`
+	Route      *Route   `json:"route,omitempty"`
+	Hosts      []string `json:"hosts,omitempty"`
+	RefNames   []string `json:"refNames,omitempty"`
+	Strategies []string `json:"strategies,omitempty"`
+}
+
+func (s *Session) DeepCopyObject() runtime.Object {
+	cp := *s
+	cp.Spec.Refs = make([]Ref, len(s.Spec.Refs))
+	copy(cp.Spec.Refs, s.Spec.Refs)
+	cp.Status.Hosts = make([]string, len(s.Status.Hosts))
+	copy(cp.Status.Hosts, s.Status.Hosts)
+	cp.Status.RefNames = make([]string, len(s.Status.RefNames))
+	copy(cp.Status.RefNames, s.Status.RefNames)
+	cp.Status.Strategies = make([]string, len(s.Status.Strategies))
+	copy(cp.Status.Strategies, s.Status.Strategies)
+	return &cp
+}
+
+type SessionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Session `json:"items"`
+}
+
+func (l *SessionList) DeepCopyObject() runtime.Object {
+	cp := *l
+	cp.Items = make([]Session, len(l.Items))
+	copy(cp.Items, l.Items)
+	return &cp
+}
+
+// --- VirtualService (simplified) ---
+
+type VirtualService struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              VirtualServiceSpec `json:"spec,omitempty"`
+}
+
+type VirtualServiceSpec struct {
+	Hosts    []string     `json:"hosts,omitempty"`
+	Gateways []string     `json:"gateways,omitempty"`
+	HTTP     []HTTPRoute  `json:"http,omitempty"`
+}
+
+type HTTPRoute struct {
+	Match   []HTTPMatchRequest `json:"match,omitempty"`
+	Route   []HTTPRouteTarget  `json:"route,omitempty"`
+	Headers *HeaderOperations  `json:"headers,omitempty"`
+}
+
+type HTTPMatchRequest struct {
+	Headers map[string]StringMatch `json:"headers,omitempty"`
+}
+
+type StringMatch struct {
+	Exact string `json:"exact,omitempty"`
+}
+
+type HTTPRouteTarget struct {
+	Destination Destination `json:"destination"`
+	Weight      int32       `json:"weight,omitempty"`
+}
+
+type Destination struct {
+	Host   string `json:"host"`
+	Subset string `json:"subset,omitempty"`
+	Port   *Port  `json:"port,omitempty"`
+}
+
+type Port struct {
+	Number uint32 `json:"number"`
+}
+
+type HeaderOperations struct {
+	Request *HeaderOperationValues `json:"request,omitempty"`
+}
+
+type HeaderOperationValues struct {
+	Add map[string]string `json:"add,omitempty"`
+}
+
+func (v *VirtualService) DeepCopyObject() runtime.Object {
+	cp := *v
+	cp.Spec.Hosts = make([]string, len(v.Spec.Hosts))
+	copy(cp.Spec.Hosts, v.Spec.Hosts)
+	cp.Spec.Gateways = make([]string, len(v.Spec.Gateways))
+	copy(cp.Spec.Gateways, v.Spec.Gateways)
+	cp.Spec.HTTP = make([]HTTPRoute, len(v.Spec.HTTP))
+	copy(cp.Spec.HTTP, v.Spec.HTTP)
+	return &cp
+}
+
+type VirtualServiceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VirtualService `json:"items"`
+}
+
+func (l *VirtualServiceList) DeepCopyObject() runtime.Object {
+	cp := *l
+	cp.Items = make([]VirtualService, len(l.Items))
+	copy(cp.Items, l.Items)
+	return &cp
+}
+
+// --- DestinationRule (simplified) ---
+
+type DestinationRule struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              DestinationRuleSpec `json:"spec,omitempty"`
+}
+
+type DestinationRuleSpec struct {
+	Host    string   `json:"host"`
+	Subsets []Subset `json:"subsets,omitempty"`
+}
+
+type Subset struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+func (d *DestinationRule) DeepCopyObject() runtime.Object {
+	cp := *d
+	cp.Spec.Subsets = make([]Subset, len(d.Spec.Subsets))
+	copy(cp.Spec.Subsets, d.Spec.Subsets)
+	return &cp
+}
+
+type DestinationRuleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []DestinationRule `json:"items"`
+}
+
+func (l *DestinationRuleList) DeepCopyObject() runtime.Object {
+	cp := *l
+	cp.Items = make([]DestinationRule, len(l.Items))
+	copy(cp.Items, l.Items)
+	return &cp
+}
+
+// --- Scheme ---
+
+func AddToScheme(s *runtime.Scheme) {
+	s.AddKnownTypeWithName(WorkspaceGV.WithKind("Session"), &Session{})
+	s.AddKnownTypeWithName(WorkspaceGV.WithKind("SessionList"), &SessionList{})
+	metav1.AddToGroupVersion(s, WorkspaceGV)
+
+	s.AddKnownTypeWithName(IstioNetGV.WithKind("VirtualService"), &VirtualService{})
+	s.AddKnownTypeWithName(IstioNetGV.WithKind("VirtualServiceList"), &VirtualServiceList{})
+	s.AddKnownTypeWithName(IstioNetGV.WithKind("DestinationRule"), &DestinationRule{})
+	s.AddKnownTypeWithName(IstioNetGV.WithKind("DestinationRuleList"), &DestinationRuleList{})
+	metav1.AddToGroupVersion(s, IstioNetGV)
+}


### PR DESCRIPTION
## Summary

- Analyze the [istio-workspace](https://github.com/maistra/istio-workspace) controller patterns against make-reconcile
- Create example at `examples/istio-workspace/` showing what can and cannot be modeled
- Document gaps and identify needed framework features

## Key finding

istio-workspace is a **mutation controller** (modify existing shared resources) while make-reconcile is a **desired-state controller** (declare what should exist). ~30% maps cleanly (Deployment cloning, DestinationRule creation), ~70% doesn't (VirtualService mutation, Gateway host injection, revert-on-delete semantics).

### What fits
- Deployment cloning → `ReconcileMany` returning cloned Deployments
- DestinationRule creation → `ReconcileMany` returning session-scoped DRs
- Status aggregation → `ReconcileStatus`

### What doesn't fit
- VirtualService mutation (partial patch of unowned resource)
- Gateway host injection (same problem)
- Revert semantics on deletion (undo partial mutations, not delete outputs)
- Dynamic discovery chain (Deployment → Service → VS → Gateway by relationship)
- Multi-Session coordination on shared resources (annotation-based multi-owner vs OwnerRef single-owner)
- Progressive status updates (10+ Status().Update calls per reconcile vs one)

### Identified feature needs
1. Foreign resource patch (scoped SSA on unowned resources)
2. Finalizer management with custom cleanup callbacks
3. Multi-owner tracking without OwnerReference GC semantics
4. Rich Fetch predicates (e.g. selector matching)

## Test plan

- [ ] Review example code compiles against make-reconcile API
- [ ] Verify analysis accuracy against istio-workspace source

Closes #8

Made with [Cursor](https://cursor.com)