### PR TITLE
feat: add finalizer management with custom cleanup callbacks

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -123,6 +123,43 @@ func applyStatus(ctx context.Context, c client.Client, gvk schema.GroupVersionKi
 	)
 }
 
+// addFinalizer adds the named finalizer to obj via merge patch. No-op if
+// the finalizer is already present.
+func addFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) error {
+	if hasFinalizer(obj, finalizer) {
+		return nil
+	}
+	base := obj.DeepCopyObject().(client.Object)
+	obj.SetFinalizers(append(obj.GetFinalizers(), finalizer))
+	return c.Patch(ctx, obj, client.MergeFrom(base))
+}
+
+// removeFinalizer removes the named finalizer from obj via merge patch.
+// No-op if the finalizer is not present.
+func removeFinalizer(ctx context.Context, c client.Client, obj client.Object, finalizer string) error {
+	if !hasFinalizer(obj, finalizer) {
+		return nil
+	}
+	base := obj.DeepCopyObject().(client.Object)
+	var remaining []string
+	for _, f := range obj.GetFinalizers() {
+		if f != finalizer {
+			remaining = append(remaining, f)
+		}
+	}
+	obj.SetFinalizers(remaining)
+	return c.Patch(ctx, obj, client.MergeFrom(base))
+}
+
+func hasFinalizer(obj client.Object, finalizer string) bool {
+	for _, f := range obj.GetFinalizers() {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
 func isNotFound(err error) bool {
 	// apimachinery errors implement StatusError with a reason.
 	type statusErr interface {

--- a/fakecache_test.go
+++ b/fakecache_test.go
@@ -114,6 +114,7 @@ func (fi *fakeInformer) IsStopped() bool                        { return false }
 // Used by internal tests that need features like statusPatchErr injection.
 type fakeClient struct {
 	client.Client
+	patches        int
 	statusPatches  int
 	statusPatchErr error
 
@@ -122,6 +123,7 @@ type fakeClient struct {
 }
 
 func (f *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	f.patches++
 	return nil
 }
 

--- a/finalizer.go
+++ b/finalizer.go
@@ -1,0 +1,47 @@
+package makereconcile
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// cleanupEntry wraps a type-erased cleanup function registered via OnDelete.
+type cleanupEntry struct {
+	fn func(*HandlerContext, client.Object) error
+}
+
+// OnDelete registers a cleanup callback that runs when a primary resource is
+// being deleted (DeletionTimestamp set, finalizer pending). The framework
+// automatically manages a finalizer on the primary: it adds the finalizer on
+// first reconciliation and removes it after the cleanup callback succeeds.
+//
+// The callback receives a HandlerContext so it can Fetch resources needed for
+// cleanup. Return nil to indicate cleanup succeeded (finalizer will be removed).
+// Return an error to retry on the next event (finalizer stays in place).
+//
+// One registration per primary GVK. Calling OnDelete again for the same primary
+// type replaces the previous callback.
+//
+// Usage:
+//
+//	platforms := mr.Watch[*Platform](mgr, mr.WithGenerationChanged())
+//
+//	mr.OnDelete(mgr, platforms, func(hc *mr.HandlerContext, p *Platform) error {
+//	    vs := mr.Fetch(hc, virtualServices, mr.FilterName(p.Name+"-vs", p.Namespace))
+//	    if vs != nil {
+//	        // revert injected route
+//	    }
+//	    return nil
+//	})
+func OnDelete[P client.Object](mgr *Manager, primary *Collection[P], fn func(*HandlerContext, P) error) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if mgr.cleanupFns == nil {
+		mgr.cleanupFns = make(map[schema.GroupVersionKind]cleanupEntry)
+	}
+	mgr.cleanupFns[primary.gvk] = cleanupEntry{
+		fn: func(hc *HandlerContext, obj client.Object) error {
+			return fn(hc, obj.(P))
+		},
+	}
+}

--- a/finalizer_test.go
+++ b/finalizer_test.go
@@ -1,0 +1,664 @@
+package makereconcile
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestOnDeleteRegistration(t *testing.T) {
+	s := coreScheme()
+	mgr := &Manager{
+		scheme:          s,
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "default",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	if !mgr.hasCleanup(cmGVK) {
+		t.Error("expected cleanup registered for ConfigMap GVK")
+	}
+}
+
+func TestFinalizerAddedOnFirstReconcile(t *testing.T) {
+	s := coreScheme()
+	fc := &fakeClient{}
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", UID: "uid-1"},
+	})
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+
+	// The store should now have the ConfigMap with the finalizer set because
+	// addFinalizer patches the object via the client (which is fc here).
+	// fakeClient.Patch is a no-op, but the in-memory object gets the finalizer
+	// added before the Patch call. Let's verify through the store: since
+	// addFinalizer calls client.Patch with MergeFrom, and our fakeClient.Patch
+	// is a no-op, the store itself is NOT updated. We verify the finalizer was
+	// attempted by checking that Patch was called on the client.
+	if fc.patches < 1 {
+		t.Errorf("expected at least 1 patch call for finalizer add, got %d", fc.patches)
+	}
+}
+
+func TestCleanupRunsOnDeletion(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	var cleanupCalled bool
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupCalled = true
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		t.Error("normal reconciler should not run during deletion")
+		return nil
+	})
+
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	handler := &eventHandler{mgr: mgr, gvk: cmGVK}
+	handler.handle(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default"},
+	})
+
+	if !cleanupCalled {
+		t.Error("cleanup function should have been called")
+	}
+	// removeFinalizer should have been called via Patch
+	if fc.patches < 1 {
+		t.Errorf("expected at least 1 patch call for finalizer remove, got %d", fc.patches)
+	}
+}
+
+func TestCleanupErrorRetainsFinalizerAndEmitsEvent(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	rec := &internalEventRecorder{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+		eventRecorder:   rec,
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return fmt.Errorf("external system unavailable")
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	primary := mgr.getPrimary(context.Background(), configMaps.gvk, primaryKey)
+	mgr.runCleanup(context.Background(), configMaps.gvk, primaryKey, primary)
+
+	// Finalizer should NOT have been removed (no Patch call for remove)
+	if fc.patches != 0 {
+		t.Errorf("expected 0 patch calls when cleanup fails, got %d", fc.patches)
+	}
+
+	// Should emit a Warning event
+	var found bool
+	for _, ev := range rec.events {
+		if ev.EventType == "Warning" && ev.Reason == "CleanupFailed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CleanupFailed event, got %+v", rec.events)
+	}
+}
+
+func TestPredicateBypassForDeletion(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr, WithGenerationChanged())
+
+	var cleanupCalled bool
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupCalled = true
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	handler := &eventHandler{
+		mgr:        mgr,
+		gvk:        cmGVK,
+		predicates: mgr.watchPredicates[cmGVK],
+	}
+
+	// Same generation (normally filtered by WithGenerationChanged), but with
+	// DeletionTimestamp set. Predicates should be bypassed.
+	oldCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", Generation: 1},
+	}
+	newCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", Generation: 1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	}
+	handler.OnUpdate(oldCM, newCM)
+
+	if !cleanupCalled {
+		t.Error("cleanup should have run even though generation didn't change")
+	}
+}
+
+func TestPredicateNotBypassedWithoutCleanup(t *testing.T) {
+	s := coreScheme()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", UID: "uid-1"},
+	})
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          &fakeClient{},
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	Watch[*corev1.ConfigMap](mgr, WithGenerationChanged())
+
+	var invoked bool
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		invoked = true
+		return nil
+	})
+	// No OnDelete registered
+
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	handler := &eventHandler{
+		mgr:        mgr,
+		gvk:        cmGVK,
+		predicates: mgr.watchPredicates[cmGVK],
+	}
+
+	now := metav1.Now()
+	oldCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", Generation: 1},
+	}
+	newCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", Generation: 1,
+			DeletionTimestamp: &now,
+		},
+	}
+	handler.OnUpdate(oldCM, newCM)
+
+	// No cleanup registered, so predicate should NOT be bypassed.
+	// Generation didn't change, so the update should be rejected.
+	if invoked {
+		t.Error("reconciler should not have been invoked without cleanup registered and same generation")
+	}
+}
+
+func TestStatusReconcilerSkippedDuringDeletion(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	type cmStatus struct {
+		Ready bool `json:"ready"`
+	}
+	var statusInvoked bool
+	ReconcileStatus(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *cmStatus {
+		statusInvoked = true
+		return &cmStatus{Ready: true}
+	})
+
+	cmGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	handler := &eventHandler{mgr: mgr, gvk: cmGVK}
+	handler.handle(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default"},
+	})
+
+	if statusInvoked {
+		t.Error("status reconciler should not have been invoked during deletion")
+	}
+}
+
+func TestCleanupClearsTrackerAndLastOutputs(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	r := mgr.reconcilers[0]
+	outputKey := r.ID() + "/" + primaryKey.String()
+
+	// Seed lastOutputs and tracker.
+	mgr.mu.Lock()
+	mgr.lastOutputs[outputKey] = map[types.NamespacedName]bool{
+		{Name: "my-cm-deploy", Namespace: "default"}: true,
+	}
+	mgr.mu.Unlock()
+
+	deployGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	ref := reconcilerRef{ReconcilerID: r.ID(), PrimaryKey: primaryKey}
+	mgr.tracker.SetDeps(ref, []depKey{{GVK: deployGVK, NamespacedName: types.NamespacedName{Name: "my-cm-deploy", Namespace: "default"}}}, nil)
+
+	// Run cleanup.
+	primary := mgr.getPrimary(context.Background(), configMaps.gvk, primaryKey)
+	mgr.runCleanup(context.Background(), configMaps.gvk, primaryKey, primary)
+
+	// lastOutputs should be cleared.
+	mgr.mu.Lock()
+	if _, ok := mgr.lastOutputs[outputKey]; ok {
+		t.Error("expected lastOutputs entry to be cleared after cleanup")
+	}
+	mgr.mu.Unlock()
+
+	// Tracker should be cleared.
+	refs := mgr.tracker.Lookup(deployGVK, types.NamespacedName{Name: "my-cm-deploy", Namespace: "default"})
+	if len(refs) != 0 {
+		t.Errorf("expected tracker entry to be cleared, got %d refs", len(refs))
+	}
+}
+
+func TestFullReconcileHandlesDeletingPrimaries(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s,
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "deleting-cm", Namespace: "default", UID: "uid-1",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "normal-cm", Namespace: "default", UID: "uid-2",
+			},
+		},
+	)
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	var cleanupNames []string
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupNames = append(cleanupNames, cm.Name)
+		return nil
+	})
+
+	var reconciledNames []string
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		reconciledNames = append(reconciledNames, cm.Name)
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	mgr.fullReconcile(context.Background())
+
+	if len(cleanupNames) != 1 || cleanupNames[0] != "deleting-cm" {
+		t.Errorf("expected cleanup for deleting-cm, got %v", cleanupNames)
+	}
+	if len(reconciledNames) != 1 || reconciledNames[0] != "normal-cm" {
+		t.Errorf("expected reconcile for normal-cm only, got %v", reconciledNames)
+	}
+}
+
+func TestFinalizerNameIncludesManagerID(t *testing.T) {
+	mgr := &Manager{managerID: "my-controller"}
+	expected := "make-reconcile.io/finalizer-my-controller"
+	if got := mgr.finalizerName(); got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestCleanupCallbackReceivesHandlerContext(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s,
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-cm", Namespace: "default", UID: "uid-1",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "related-secret", Namespace: "default"},
+			Data:       map[string][]byte{"key": []byte("value")},
+		},
+	)
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	secrets := Watch[*corev1.Secret](mgr)
+
+	var fetchedSecret *corev1.Secret
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		fetchedSecret = Fetch(hc, secrets, FilterName("related-secret", cm.Namespace))
+		return nil
+	})
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	primary := mgr.getPrimary(context.Background(), configMaps.gvk, primaryKey)
+	mgr.runCleanup(context.Background(), configMaps.gvk, primaryKey, primary)
+
+	if fetchedSecret == nil {
+		t.Error("expected cleanup to be able to Fetch resources via HandlerContext")
+	}
+	if fetchedSecret.Name != "related-secret" {
+		t.Errorf("expected fetched secret name 'related-secret', got %q", fetchedSecret.Name)
+	}
+}
+
+func TestRunSubReconcilerSkipsWhenPrimaryIsDeleting(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	var invoked bool
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		invoked = true
+		return nil
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+
+	if invoked {
+		t.Error("sub-reconciler should not run when primary is being deleted")
+	}
+}
+
+func TestNoFinalizerWithoutOnDelete(t *testing.T) {
+	s := coreScheme()
+	fc := &fakeClient{}
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default", UID: "uid-1"},
+	})
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+	// No OnDelete registered
+
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	primaryKey := types.NamespacedName{Name: "my-cm", Namespace: "default"}
+	mgr.runSubReconciler(context.Background(), mgr.reconcilers[0], primaryKey)
+
+	// No cleanup registered → no finalizer Patch should happen.
+	// fakeClient.Patch is called for the output apply, but not for a finalizer.
+	// The apply uses client.Apply patch type. If no OnDelete, the finalizer
+	// add path is never entered, so only 1 Patch (for the apply).
+	if fc.patches != 1 {
+		t.Errorf("expected exactly 1 patch (output apply only), got %d", fc.patches)
+	}
+}
+
+func TestCleanupOnlyRunsOncePerPrimaryInFullReconcile(t *testing.T) {
+	s := coreScheme()
+	now := metav1.Now()
+	store := newTestStore(s, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cm", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-test"},
+		},
+	})
+	fc := &fakeClient{}
+	mgr := &Manager{
+		scheme:          s,
+		cache:           store,
+		client:          fc,
+		log:             slog.Default(),
+		watchedGVKs:     make(map[schema.GroupVersionKind]bool),
+		watchPredicates: make(map[schema.GroupVersionKind][]EventPredicate),
+		tracker:         newDependencyTracker(),
+		managerID:       "test",
+		lastOutputs:     make(map[string]map[types.NamespacedName]bool),
+	}
+
+	configMaps := Watch[*corev1.ConfigMap](mgr)
+
+	var cleanupCount int
+	OnDelete(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupCount++
+		return nil
+	})
+
+	// Two reconcilers for the same primary GVK.
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+	Reconcile(mgr, configMaps, func(hc *HandlerContext, cm *corev1.ConfigMap) *corev1.Service {
+		return nil
+	})
+
+	mgr.fullReconcile(context.Background())
+
+	if cleanupCount != 1 {
+		t.Errorf("expected cleanup to run exactly once, got %d", cleanupCount)
+	}
+}
+

--- a/manager.go
+++ b/manager.go
@@ -48,6 +48,11 @@ type Manager struct {
 	// when the set of outputs shrinks.
 	lastOutputs map[string]map[types.NamespacedName]bool
 
+	// cleanupFns maps a primary GVK to its registered cleanup function.
+	// Registered via OnDelete. When the primary is being deleted (finalizer
+	// pending), the cleanup function runs instead of normal reconciliation.
+	cleanupFns map[schema.GroupVersionKind]cleanupEntry
+
 	// pendingWatches holds GVKs whose CRDs were not available at startup.
 	// A background goroutine retries registration periodically.
 	pendingWatches             []schema.GroupVersionKind
@@ -336,12 +341,22 @@ func (h *eventHandler) OnUpdate(oldObj, newObj interface{}) {
 	if !ok {
 		return
 	}
-	oldCObj, _ := oldObj.(client.Object)
-	for _, p := range h.predicates {
-		if p.Update != nil && !p.Update(oldCObj, newCObj) {
-			return
+
+	// Bypass predicates when the object is being deleted and a cleanup
+	// function is registered for this GVK. Setting DeletionTimestamp does
+	// not bump metadata.generation, so WithGenerationChanged() would
+	// silently drop the event and leave the finalizer stuck.
+	isDeleting := newCObj.GetDeletionTimestamp() != nil && h.mgr.hasCleanup(h.gvk)
+
+	if !isDeleting {
+		oldCObj, _ := oldObj.(client.Object)
+		for _, p := range h.predicates {
+			if p.Update != nil && !p.Update(oldCObj, newCObj) {
+				return
+			}
 		}
 	}
+
 	h.handle(newCObj)
 }
 
@@ -365,8 +380,35 @@ func (h *eventHandler) handle(obj client.Object) {
 	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	ctx := context.Background()
 
+	// If this event is for a primary resource that is being deleted and has
+	// a cleanup function registered, run cleanup and skip normal reconciliation.
+	isPrimaryForAnyReconciler := false
+	for _, r := range h.mgr.reconcilers {
+		if r.PrimaryGVK() == h.gvk {
+			isPrimaryForAnyReconciler = true
+			break
+		}
+	}
+	if !isPrimaryForAnyReconciler {
+		for _, sr := range h.mgr.statusReconcilers {
+			if sr.PrimaryGVK() == h.gvk {
+				isPrimaryForAnyReconciler = true
+				break
+			}
+		}
+	}
+
+	if isPrimaryForAnyReconciler && h.mgr.hasCleanup(h.gvk) {
+		primary := h.mgr.getPrimary(ctx, h.gvk, nn)
+		if primary != nil && primary.GetDeletionTimestamp() != nil {
+			h.mgr.runCleanup(ctx, h.gvk, nn, primary)
+			return
+		}
+	}
+
 	// Track which primaries were affected so we can run status reconcilers after.
 	affectedPrimaries := make(map[schema.GroupVersionKind]map[types.NamespacedName]bool)
+	deletingPrimaries := make(map[types.NamespacedName]bool)
 	recordAffected := func(gvk schema.GroupVersionKind, key types.NamespacedName) {
 		if affectedPrimaries[gvk] == nil {
 			affectedPrimaries[gvk] = make(map[types.NamespacedName]bool)
@@ -397,6 +439,7 @@ func (h *eventHandler) handle(obj client.Object) {
 	}
 
 	// Phase 2: run status reconcilers for affected primaries + direct deps.
+	// Skip status reconcilers for primaries that are being deleted.
 
 	// Is this a primary resource for any status reconciler?
 	for _, sr := range h.mgr.statusReconcilers {
@@ -418,6 +461,16 @@ func (h *eventHandler) handle(obj client.Object) {
 	for _, sr := range h.mgr.statusReconcilers {
 		keys := affectedPrimaries[sr.PrimaryGVK()]
 		for key := range keys {
+			if deletingPrimaries[key] {
+				continue
+			}
+			if h.mgr.hasCleanup(sr.PrimaryGVK()) {
+				primary := h.mgr.getPrimary(ctx, sr.PrimaryGVK(), key)
+				if primary != nil && primary.GetDeletionTimestamp() != nil {
+					deletingPrimaries[key] = true
+					continue
+				}
+			}
 			h.mgr.runStatusReconciler(ctx, sr, key)
 		}
 	}
@@ -425,6 +478,26 @@ func (h *eventHandler) handle(obj client.Object) {
 
 func (m *Manager) runSubReconciler(ctx context.Context, r subReconciler, primaryKey types.NamespacedName) {
 	outputKey := fmt.Sprintf("%s/%s", r.ID(), primaryKey.String())
+
+	// If a cleanup function is registered for this primary GVK, handle
+	// finalizer lifecycle: skip if deleting, add finalizer if missing.
+	if m.hasCleanup(r.PrimaryGVK()) {
+		primary := m.getPrimary(ctx, r.PrimaryGVK(), primaryKey)
+		if primary == nil {
+			return
+		}
+		if primary.GetDeletionTimestamp() != nil {
+			return
+		}
+		if !hasFinalizer(primary, m.finalizerName()) {
+			if err := addFinalizer(ctx, m.client, primary, m.finalizerName()); err != nil {
+				m.log.Error("add finalizer failed",
+					"primary", primaryKey,
+					"error", err,
+				)
+			}
+		}
+	}
 
 	desired, err := r.Reconcile(ctx, m, primaryKey)
 	if err != nil {
@@ -543,7 +616,78 @@ func (m *Manager) recordEvent(obj client.Object, eventType, reason, messageFmt s
 	m.eventRecorder.Eventf(obj, eventType, reason, messageFmt, args...)
 }
 
+func (m *Manager) finalizerName() string {
+	return "make-reconcile.io/finalizer-" + m.managerID
+}
+
+func (m *Manager) hasCleanup(gvk schema.GroupVersionKind) bool {
+	_, ok := m.cleanupFns[gvk]
+	return ok
+}
+
+// runCleanup executes the cleanup callback for a deleting primary, then removes
+// the finalizer on success. On failure the finalizer stays in place so
+// Kubernetes will re-trigger the event.
+func (m *Manager) runCleanup(ctx context.Context, gvk schema.GroupVersionKind, primaryKey types.NamespacedName, primary client.Object) {
+	ce, ok := m.cleanupFns[gvk]
+	if !ok {
+		return
+	}
+
+	hc := newHandlerContext(ctx, m, primary)
+	if err := ce.fn(hc, primary); err != nil {
+		m.log.Error("cleanup failed, finalizer retained",
+			"primary", primaryKey,
+			"error", err,
+		)
+		m.recordEvent(primary, "Warning", "CleanupFailed",
+			"Cleanup failed: %v", err)
+		return
+	}
+
+	if err := removeFinalizer(ctx, m.client, primary, m.finalizerName()); err != nil {
+		m.log.Error("remove finalizer failed",
+			"primary", primaryKey,
+			"error", err,
+		)
+		return
+	}
+
+	// Clear lastOutputs and tracker entries for this primary.
+	m.mu.Lock()
+	for key := range m.lastOutputs {
+		if strings.HasSuffix(key, "/"+primaryKey.String()) {
+			delete(m.lastOutputs, key)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, r := range m.reconcilers {
+		if r.PrimaryGVK() == gvk {
+			ref := reconcilerRef{ReconcilerID: r.ID(), PrimaryKey: primaryKey}
+			m.tracker.SetDeps(ref, nil, nil)
+		}
+	}
+	for _, sr := range m.statusReconcilers {
+		if sr.PrimaryGVK() == gvk {
+			ref := reconcilerRef{ReconcilerID: sr.ID(), PrimaryKey: primaryKey}
+			m.tracker.SetDeps(ref, nil, nil)
+		}
+	}
+
+	m.recordEvent(primary, "Normal", "CleanupComplete",
+		"Cleanup complete, finalizer removed")
+}
+
 func (m *Manager) fullReconcile(ctx context.Context) {
+	// Track primaries already cleaned up to avoid running cleanup more than
+	// once when multiple reconcilers share the same primary GVK.
+	type cleanupKey struct {
+		GVK schema.GroupVersionKind
+		NN  types.NamespacedName
+	}
+	cleanedUp := make(map[cleanupKey]bool)
+
 	// Phase 1: all output reconcilers.
 	for _, r := range m.reconcilers {
 		list := newListForGVK(m.scheme, r.PrimaryGVK())
@@ -564,11 +708,22 @@ func (m *Manager) fullReconcile(ctx context.Context) {
 				continue
 			}
 			nn := types.NamespacedName{Name: cObj.GetName(), Namespace: cObj.GetNamespace()}
+
+			if cObj.GetDeletionTimestamp() != nil && m.hasCleanup(r.PrimaryGVK()) {
+				ck := cleanupKey{GVK: r.PrimaryGVK(), NN: nn}
+				if !cleanedUp[ck] {
+					m.runCleanup(ctx, r.PrimaryGVK(), nn, cObj)
+					cleanedUp[ck] = true
+				}
+				continue
+			}
+
 			m.runSubReconciler(ctx, r, nn)
 		}
 	}
 
 	// Phase 2: all status reconcilers (after outputs are applied).
+	// Skip primaries that are being deleted.
 	for _, sr := range m.statusReconcilers {
 		list := newListForGVK(m.scheme, sr.PrimaryGVK())
 		if err := m.cache.List(ctx, list); err != nil {
@@ -585,6 +740,9 @@ func (m *Manager) fullReconcile(ctx context.Context) {
 		for _, item := range items {
 			cObj, ok := item.(client.Object)
 			if !ok {
+				continue
+			}
+			if cObj.GetDeletionTimestamp() != nil && m.hasCleanup(sr.PrimaryGVK()) {
 				continue
 			}
 			nn := types.NamespacedName{Name: cObj.GetName(), Namespace: cObj.GetNamespace()}

--- a/mrtest/harness_test.go
+++ b/mrtest/harness_test.go
@@ -589,3 +589,233 @@ func TestMultipleReconcilersSameOutputGVK(t *testing.T) {
 	result.AssertApplied("svc-app", "default")
 	result.AssertApplied("svc-worker", "default")
 }
+
+// --- OnDelete / finalizer tests ---
+
+func TestOnDeleteFinalizerAddedOnReconcile(t *testing.T) {
+	h := mrtest.NewHarness(t, testScheme())
+	mgr := h.Manager()
+
+	configMaps := mr.Watch[*corev1.ConfigMap](mgr)
+	mr.OnDelete(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	mr.Reconcile(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	h.SetObject(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid-1"},
+	})
+
+	result := h.Reconcile(cmGVK, types.NamespacedName{Name: "app", Namespace: "default"})
+	result.AssertApplied("app-deploy", "default")
+
+	// Verify the finalizer was added to the primary in the store.
+	cm := mrtest.GetObject[*corev1.ConfigMap](h, "app", "default")
+	if cm == nil {
+		t.Fatal("expected ConfigMap in store")
+	}
+	found := false
+	for _, f := range cm.GetFinalizers() {
+		if f == "make-reconcile.io/finalizer-default" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected finalizer on ConfigMap, got finalizers: %v", cm.GetFinalizers())
+	}
+}
+
+func TestOnDeleteCleanupRunsOnDeletion(t *testing.T) {
+	h := mrtest.NewHarness(t, testScheme())
+	mgr := h.Manager()
+
+	configMaps := mr.Watch[*corev1.ConfigMap](mgr)
+
+	var cleanupCalled bool
+	mr.OnDelete(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupCalled = true
+		return nil
+	})
+
+	mr.Reconcile(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	// First reconcile: adds finalizer.
+	h.SetObject(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", UID: "uid-1"},
+	})
+	h.Reconcile(cmGVK, types.NamespacedName{Name: "app", Namespace: "default"})
+
+	// Simulate deletion: set DeletionTimestamp and keep the finalizer.
+	now := metav1.Now()
+	h.SetObject(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-default"},
+		},
+	})
+	result := h.Reconcile(cmGVK, types.NamespacedName{Name: "app", Namespace: "default"})
+
+	if !cleanupCalled {
+		t.Error("expected cleanup to be called on deletion")
+	}
+
+	// Output should not have been applied (cleanup path, not normal reconcile).
+	result.AssertAppliedCount(0)
+
+	// Finalizer should have been removed.
+	cm := mrtest.GetObject[*corev1.ConfigMap](h, "app", "default")
+	if cm != nil {
+		for _, f := range cm.GetFinalizers() {
+			if f == "make-reconcile.io/finalizer-default" {
+				t.Error("finalizer should have been removed after cleanup")
+			}
+		}
+	}
+}
+
+func TestOnDeleteCleanupCanFetchResources(t *testing.T) {
+	h := mrtest.NewHarness(t, testScheme())
+	mgr := h.Manager()
+
+	configMaps := mr.Watch[*corev1.ConfigMap](mgr)
+	secrets := mr.Watch[*corev1.Secret](mgr)
+
+	var fetchedSecretName string
+	mr.OnDelete(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) error {
+		sec := mr.Fetch(hc, secrets, mr.FilterName(cm.Name+"-secret", cm.Namespace))
+		if sec != nil {
+			fetchedSecretName = sec.Name
+		}
+		return nil
+	})
+
+	mr.Reconcile(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	now := metav1.Now()
+	h.SetObject(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app", Namespace: "default", UID: "uid-1",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"make-reconcile.io/finalizer-default"},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-secret", Namespace: "default"},
+		},
+	)
+
+	h.Reconcile(cmGVK, types.NamespacedName{Name: "app", Namespace: "default"})
+
+	if fetchedSecretName != "app-secret" {
+		t.Errorf("expected cleanup to fetch 'app-secret', got %q", fetchedSecretName)
+	}
+}
+
+func TestOnDeleteStatusSkippedDuringDeletion(t *testing.T) {
+	h := mrtest.NewHarness(t, testScheme())
+	mgr := h.Manager()
+
+	configMaps := mr.Watch[*corev1.ConfigMap](mgr)
+
+	mr.OnDelete(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) error {
+		return nil
+	})
+
+	mr.Reconcile(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		return nil
+	})
+
+	type status struct {
+		Done bool `json:"done"`
+	}
+	var statusInvoked bool
+	mr.ReconcileStatus(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *status {
+		statusInvoked = true
+		return &status{Done: true}
+	})
+
+	now := metav1.Now()
+	h.SetObject(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app", Namespace: "default", UID: "uid-1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"make-reconcile.io/finalizer-default"},
+		},
+	})
+
+	h.Reconcile(cmGVK, types.NamespacedName{Name: "app", Namespace: "default"})
+
+	if statusInvoked {
+		t.Error("status reconciler should not run during deletion")
+	}
+}
+
+func TestSettleHandlesDeletingPrimaries(t *testing.T) {
+	h := mrtest.NewHarness(t, testScheme())
+	mgr := h.Manager()
+
+	configMaps := mr.Watch[*corev1.ConfigMap](mgr)
+
+	var cleanupNames []string
+	var reconcileNames []string
+
+	mr.OnDelete(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) error {
+		cleanupNames = append(cleanupNames, cm.Name)
+		return nil
+	})
+
+	mr.Reconcile(mgr, configMaps, func(hc *mr.HandlerContext, cm *corev1.ConfigMap) *appsv1.Deployment {
+		reconcileNames = append(reconcileNames, cm.Name)
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: cm.Name + "-deploy", Namespace: cm.Namespace},
+		}
+	})
+
+	now := metav1.Now()
+	h.SetObject(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "alive", Namespace: "default", UID: "uid-1",
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dying", Namespace: "default", UID: "uid-2",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{"make-reconcile.io/finalizer-default"},
+			},
+		},
+	)
+
+	h.Settle()
+
+	if len(cleanupNames) != 1 || cleanupNames[0] != "dying" {
+		t.Errorf("expected cleanup for 'dying' only, got %v", cleanupNames)
+	}
+
+	foundAlive := false
+	for _, n := range reconcileNames {
+		if n == "alive" {
+			foundAlive = true
+		}
+		if n == "dying" {
+			t.Error("'dying' should not have been reconciled normally")
+		}
+	}
+	if !foundAlive {
+		t.Error("expected 'alive' to be reconciled normally")
+	}
+}

--- a/mrtest/store.go
+++ b/mrtest/store.go
@@ -213,9 +213,11 @@ func (s *ObjectStore) DeleteAllOf(_ context.Context, _ client.Object, _ ...clien
 	return fmt.Errorf("not implemented")
 }
 
-func (s *ObjectStore) Patch(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+func (s *ObjectStore) Patch(_ context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
 	s.mu.Lock()
-	s.Applied = append(s.Applied, obj)
+	if patch.Type() == types.ApplyPatchType {
+		s.Applied = append(s.Applied, obj)
+	}
 	gvk := s.resolveGVK(obj)
 	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 	s.objects[objectKey{GVK: gvk, Key: nn}] = obj.DeepCopyObject().(client.Object)


### PR DESCRIPTION
## Summary

- Adds `OnDelete[P]` registration function for cleanup callbacks that run before a primary resource is deleted
- Framework automatically manages a finalizer on primary resources: adds on first reconcile, removes after cleanup succeeds
- Predicate bypass ensures `WithGenerationChanged()` doesn't silently drop deletion events (DeletionTimestamp doesn't bump generation)
- Status reconcilers and normal sub-reconcilers are skipped during deletion
- `fullReconcile` routes deleting primaries to cleanup instead of normal reconciliation
- mrtest `ObjectStore.Patch` now only tracks SSA patches as Applied (merge patches for finalizer ops are stored but not recorded)

Closes #11

## Test plan

- [x] `TestOnDeleteRegistration` - cleanup registered for GVK
- [x] `TestFinalizerAddedOnFirstReconcile` - finalizer patch attempted on first reconcile
- [x] `TestCleanupRunsOnDeletion` - cleanup runs, normal reconciler skipped
- [x] `TestCleanupErrorRetainsFinalizerAndEmitsEvent` - failed cleanup keeps finalizer, emits Warning
- [x] `TestPredicateBypassForDeletion` - WithGenerationChanged bypassed when deleting
- [x] `TestPredicateNotBypassedWithoutCleanup` - no bypass without OnDelete
- [x] `TestStatusReconcilerSkippedDuringDeletion` - status skipped during deletion
- [x] `TestCleanupClearsTrackerAndLastOutputs` - tracker/lastOutputs cleaned up
- [x] `TestFullReconcileHandlesDeletingPrimaries` - fullReconcile routes to cleanup
- [x] `TestCleanupOnlyRunsOncePerPrimaryInFullReconcile` - dedup across reconcilers
- [x] `TestRunSubReconcilerSkipsWhenPrimaryIsDeleting` - dep-triggered skip
- [x] `TestNoFinalizerWithoutOnDelete` - no finalizer when no OnDelete
- [x] `TestCleanupCallbackReceivesHandlerContext` - Fetch works in cleanup
- [x] mrtest harness integration tests (finalizer add, cleanup, status skip, settle)

Made with [Cursor](https://cursor.com)